### PR TITLE
Ability to enable-disable spring-session

### DIFF
--- a/grails-app/conf/DefaultSessionConfig.groovy
+++ b/grails-app/conf/DefaultSessionConfig.groovy
@@ -1,4 +1,5 @@
 springsession {
+    active = true
     maxInactiveIntervalInSeconds = 1800
     redis {
         connectionFactory {

--- a/src/main/groovy/SpringSessionGrailsPlugin.groovy
+++ b/src/main/groovy/SpringSessionGrailsPlugin.groovy
@@ -35,6 +35,12 @@ class SpringSessionGrailsPlugin extends Plugin {
             SpringSessionUtils.application = grailsApplication
             ConfigObject conf = SpringSessionUtils.sessionConfig
 
+            if (!conf || !conf.active) {
+                String message = 'Spring session is disabled, not loading'
+                log.warn message
+                return
+            }
+
             springSessionConfig(SpringSessionConfig) {
                 grailsApplication = grailsApplication
             }

--- a/src/main/groovy/SpringSessionGrailsPlugin.groovy
+++ b/src/main/groovy/SpringSessionGrailsPlugin.groovy
@@ -36,8 +36,7 @@ class SpringSessionGrailsPlugin extends Plugin {
             ConfigObject conf = SpringSessionUtils.sessionConfig
 
             if (!conf || !conf.active) {
-                String message = 'Spring session is disabled, not loading'
-                log.warn message
+                log.warn 'Spring session is disabled, not loading'
                 return
             }
 

--- a/src/main/groovy/utils/SpringSessionUtils.groovy
+++ b/src/main/groovy/utils/SpringSessionUtils.groovy
@@ -40,5 +40,10 @@ class SpringSessionUtils {
         MutablePropertySources propertySources = application.mainContext.environment.propertySources
         propertySources.addFirst(propertySource)
         application.config.springsession = config
+        if(!config.active){
+            // set the store type to none to disable session auto-configuration
+            PropertySource<Properties> systemProperties = (PropertySource<Properties>) propertySources.get('systemProperties')
+            systemProperties.source.put('spring.session.store-type', 'none')
+        }
     }
 }

--- a/src/main/groovy/utils/SpringSessionUtils.groovy
+++ b/src/main/groovy/utils/SpringSessionUtils.groovy
@@ -42,7 +42,7 @@ class SpringSessionUtils {
         application.config.springsession = config
         if(!config.active){
             // set the store type to none to disable session auto-configuration
-            PropertySource<Properties> systemProperties = (PropertySource<Properties>) propertySources.get('systemProperties')
+            PropertySource systemProperties = propertySources.get('systemProperties')
             systemProperties.source.put('spring.session.store-type', 'none')
         }
     }


### PR DESCRIPTION
Connects #27 

- Added property to set activity status of Spring Session
- If active = false, skip doWithSpring init & set spring.session.store-type=none to evade session auto-configuration